### PR TITLE
Avoid spurious posix.df test failures when docker daemon running.

### DIFF
--- a/testsuite/testPosix.ml
+++ b/testsuite/testPosix.ml
@@ -94,6 +94,6 @@ let () =
       "You say goodbye, and I say hello!";
     ]
   |* find_suite
-  |& assert_process_status "df" (fun () -> df []) (Rashell_Command.WEXITED 0)
+  |& assert_process_status "df" (fun () -> df ["/bin"]) (Rashell_Command.WEXITED 0)
   |& assert_process_status "du" (fun () -> du []) (Rashell_Command.WEXITED 0)
   |> register


### PR DESCRIPTION
On Debian wheezy, the unit tests (and thus opam install) run by a non-root user fail because `df` exits with error 1 as it cannot access
`/var/lib/docker/aufs`.

    From BROKEN Thu Dec  3 12:11:53 2015
    Test-Case: posix.df
    Test-Expected: WEXITED(0)
    Test-Got: WEXITED(1)
    Test-Outcome-Brief: ~
    Test-Outcome: failed

    $ df > /dev/null
    df: `/var/lib/docker/aufs': Permission denied
    $ echo $?
    1