### PR TITLE
Fix Rashell_Docker.run (need to remove trailing newline).

### DIFF
--- a/src/rashell_Docker.ml
+++ b/src/rashell_Docker.ml
@@ -327,7 +327,7 @@ let __run funcname exec detach interactive cmd =
   with Invalid_argument _ as exn -> Lwt.fail exn
 
 let run =
-  __run "run" exec_utility true false
+  __run "run" (exec_utility ~chomp:true) true false
 
 let run_utility =
   __run "run_utility" exec_utility false false


### PR DESCRIPTION
The returned id could not be used as-is (e.g. in `stop` or `rm`) because of the trailing `\n`.